### PR TITLE
Update workflow files to use npm ci

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@main
       - name: Install dependencies
         run: |
-          npm install
+          npm ci
       - name: Lint files
         run: |
           npm run lint

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@main
       - name: Install dependencies
         run: |
-          npm install
+          npm ci
       - name: Run tests
         run: |
           npm run test


### PR DESCRIPTION
`npm ci` should be preferred over `npm install` when installing locked dependency versions.